### PR TITLE
Add generateJob() and GenerateRandomHash

### DIFF
--- a/Sources/Extensions/CronJobExtensions+batch.v1.swift
+++ b/Sources/Extensions/CronJobExtensions+batch.v1.swift
@@ -16,20 +16,12 @@
 
 import Foundation
 
-// MARK: - createJobFromCronjobErrors
-
-enum createJobFromCronjobErrors: Error {
-	case jobSpecDoesntExist
-	case jobMetadataDoesntExist
-	case cronjobNameDoesntExist
-}
-
 public extension batch.v1.CronJob {
 	func generateJob(withName name: String = "manual") throws -> batch.v1.Job {
-		guard let jobTemplateSpec = spec?.jobTemplate.spec else { throw createJobFromCronjobErrors.jobSpecDoesntExist }
-		guard let cronJobName = self.name else { throw createJobFromCronjobErrors.cronjobNameDoesntExist }
+		guard let jobTemplateSpec = spec?.jobTemplate.spec else { throw SwiftkubeModelError.fieldDoesntExist("Job spec") }
+		guard let cronJobName = self.name else { throw SwiftkubeModelError.fieldDoesntExist("Cronjob Name") }
 		let jobName = "\(cronJobName)-\(name)-\(GenerateRandomHash(length: 3))"
-		guard let metadata = metadata else { throw createJobFromCronjobErrors.jobMetadataDoesntExist }
+		guard let metadata = metadata else { throw SwiftkubeModelError.fieldDoesntExist("Job Metadata") }
 		var existingMetadata = metadata
 		existingMetadata.name = jobName
 		var job = batch.v1.Job()

--- a/Sources/Extensions/CronJobExtensions+batch.v1.swift
+++ b/Sources/Extensions/CronJobExtensions+batch.v1.swift
@@ -1,0 +1,41 @@
+//
+// Copyright 2020 Swiftkube Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+// MARK: - createJobFromCronjobErrors
+
+enum createJobFromCronjobErrors: Error {
+	case jobSpecDoesntExist
+	case jobMetadataDoesntExist
+	case cronjobNameDoesntExist
+}
+
+public extension batch.v1.CronJob {
+	func generateJob() throws -> batch.v1.Job {
+		guard let jobTemplateSpec = spec?.jobTemplate.spec else { throw createJobFromCronjobErrors.jobSpecDoesntExist }
+		guard let name = name else { throw createJobFromCronjobErrors.cronjobNameDoesntExist }
+		let jobName = "\(name)-manual-\(GenerateRandomHash(length: 3))"
+		guard let metadata = metadata else { throw createJobFromCronjobErrors.jobMetadataDoesntExist }
+		var existingMetadata = metadata
+		existingMetadata.name = jobName
+		var job = batch.v1.Job()
+		existingMetadata.resourceVersion = nil
+		job.spec = jobTemplateSpec
+		job.metadata = existingMetadata
+		return job
+	}
+}

--- a/Sources/Extensions/CronJobExtensions+batch.v1.swift
+++ b/Sources/Extensions/CronJobExtensions+batch.v1.swift
@@ -25,10 +25,10 @@ enum createJobFromCronjobErrors: Error {
 }
 
 public extension batch.v1.CronJob {
-	func generateJob() throws -> batch.v1.Job {
+	func generateJob(withName name: String = "manual") throws -> batch.v1.Job {
 		guard let jobTemplateSpec = spec?.jobTemplate.spec else { throw createJobFromCronjobErrors.jobSpecDoesntExist }
-		guard let name = name else { throw createJobFromCronjobErrors.cronjobNameDoesntExist }
-		let jobName = "\(name)-manual-\(GenerateRandomHash(length: 3))"
+		guard let cronJobName = self.name else { throw createJobFromCronjobErrors.cronjobNameDoesntExist }
+		let jobName = "\(cronJobName)-\(name)-\(GenerateRandomHash(length: 3))"
 		guard let metadata = metadata else { throw createJobFromCronjobErrors.jobMetadataDoesntExist }
 		var existingMetadata = metadata
 		existingMetadata.name = jobName

--- a/Sources/Extensions/Hashes.swift
+++ b/Sources/Extensions/Hashes.swift
@@ -1,0 +1,39 @@
+//
+// Copyright 2020 Swiftkube Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// GenerateRandomHash returns a three character. I
+func GenerateRandomHash(length: Int) -> String {
+	if length == 0 {
+		return ""
+	}
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	let alphanums = ["b", "c", "d", "f", "g", "h", "j", "k", "l", "m", "n", "p", "q", "r", "s", "t", "v", "w", "x", "z", "2", "4", "5", "6", "7", "8", "9"]
+	var seedAlphanum = alphanums.randomElement()!
+	var slug = seedAlphanum
+	var neededAlphanums = length - 1
+	while neededAlphanums > 0 {
+		let nextAlphanum = alphanums.randomElement()!
+		if nextAlphanum != seedAlphanum {
+			seedAlphanum = nextAlphanum
+			slug = slug + nextAlphanum
+			neededAlphanums -= 1
+		}
+	}
+	return slug
+}

--- a/Sources/SwiftkubeModel.swift
+++ b/Sources/SwiftkubeModel.swift
@@ -22,4 +22,6 @@ public enum SwiftkubeModelError: Error {
 	case unknownAPIObject(String)
 	/// Thrown on decoding errors.
 	case decodingError(String)
+	/// Thrown when a Kubernetes object is missing a field that is requied to perform an operation
+	case fieldDoesntExist(String)
 }

--- a/Tests/SwiftkubeModelTests/CronJobExtensionsTests.swift
+++ b/Tests/SwiftkubeModelTests/CronJobExtensionsTests.swift
@@ -1,0 +1,35 @@
+//
+// Copyright 2020 Swiftkube Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import SwiftkubeModel
+import XCTest
+
+fileprivate func dummyCronJob() -> batch.v1.CronJob {
+	let jobTemplate = batch.v1.JobTemplateSpec(metadata: meta.v1.ObjectMeta(), spec: batch.v1.JobSpec(template: core.v1.PodTemplateSpec()))
+	
+	return batch.v1.CronJob(metadata: meta.v1.ObjectMeta(clusterName: "directly-apply-main-cluster", creationTimestamp: Date(), deletionGracePeriodSeconds: 100, managedFields: [meta.v1.ManagedFieldsEntry](), name: "great-cronjob", namespace: "default", ownerReferences: [meta.v1.OwnerReference](), resourceVersion: "appv1", uid: "F3493650-A9DF-410F-B1A4-E8F5386E5B53"), spec: batch.v1.CronJobSpec(failedJobsHistoryLimit: 5, jobTemplate: jobTemplate, schedule: "15 10 * * *", startingDeadlineSeconds: 100, successfulJobsHistoryLimit: 2, suspend: false), status: batch.v1.CronJobStatus(active: [core.v1.ObjectReference](), lastScheduleTime: Date()))
+}
+
+// MARK: - CronJobExtensionsTests
+
+final class CronJobExtensionsTests: XCTestCase {
+	
+	func testGetJobFromCronjob() throws {
+		let exampleCronJob = dummyCronJob()
+		let job = try exampleCronJob.generateJob()
+		XCTAssertTrue(((job.name?.starts(with: "great-cronjob-manual-")) != nil))
+	}
+}

--- a/Tests/SwiftkubeModelTests/CronJobExtensionsTests.swift
+++ b/Tests/SwiftkubeModelTests/CronJobExtensionsTests.swift
@@ -17,19 +17,19 @@
 @testable import SwiftkubeModel
 import XCTest
 
-fileprivate func dummyCronJob() -> batch.v1.CronJob {
+private func dummyCronJob() -> batch.v1.CronJob {
 	let jobTemplate = batch.v1.JobTemplateSpec(metadata: meta.v1.ObjectMeta(), spec: batch.v1.JobSpec(template: core.v1.PodTemplateSpec()))
-	
+
 	return batch.v1.CronJob(metadata: meta.v1.ObjectMeta(clusterName: "directly-apply-main-cluster", creationTimestamp: Date(), deletionGracePeriodSeconds: 100, managedFields: [meta.v1.ManagedFieldsEntry](), name: "great-cronjob", namespace: "default", ownerReferences: [meta.v1.OwnerReference](), resourceVersion: "appv1", uid: "F3493650-A9DF-410F-B1A4-E8F5386E5B53"), spec: batch.v1.CronJobSpec(failedJobsHistoryLimit: 5, jobTemplate: jobTemplate, schedule: "15 10 * * *", startingDeadlineSeconds: 100, successfulJobsHistoryLimit: 2, suspend: false), status: batch.v1.CronJobStatus(active: [core.v1.ObjectReference](), lastScheduleTime: Date()))
 }
 
 // MARK: - CronJobExtensionsTests
 
 final class CronJobExtensionsTests: XCTestCase {
-	
+
 	func testGetJobFromCronjob() throws {
 		let exampleCronJob = dummyCronJob()
 		let job = try exampleCronJob.generateJob()
-		XCTAssertTrue(((job.name?.starts(with: "great-cronjob-manual-")) != nil))
+		XCTAssertTrue((job.name?.starts(with: "great-cronjob-manual-")) != nil)
 	}
 }

--- a/Tests/SwiftkubeModelTests/HashesTests.swift
+++ b/Tests/SwiftkubeModelTests/HashesTests.swift
@@ -1,0 +1,33 @@
+//
+// Copyright 2020 Swiftkube Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable import SwiftkubeModel
+import XCTest
+
+let exampleHash = GenerateRandomHash(length: 3)
+
+let exampleZeroLengthHash = GenerateRandomHash(length: 0)
+
+// MARK: - HashesTests
+
+final class HashesTests: XCTestCase {
+
+    func testGenerateRandomHash() throws {
+
+		XCTAssertEqual(exampleHash.count, 3)
+		XCTAssertEqual(exampleZeroLengthHash.count, 0)
+    }
+}

--- a/Tests/SwiftkubeModelTests/HashesTests.swift
+++ b/Tests/SwiftkubeModelTests/HashesTests.swift
@@ -25,9 +25,9 @@ let exampleZeroLengthHash = GenerateRandomHash(length: 0)
 
 final class HashesTests: XCTestCase {
 
-    func testGenerateRandomHash() throws {
+	func testGenerateRandomHash() throws {
 
 		XCTAssertEqual(exampleHash.count, 3)
 		XCTAssertEqual(exampleZeroLengthHash.count, 0)
-    }
+	}
 }


### PR DESCRIPTION
This commit adds functionality to generate a job from a cronjob. To do this locally we need to emulate the code to generate the hashes. Both files have been moved from SwiftkubeClient