### PR TITLE
Make `GroupVersionResource` conform to `Codable`

### DIFF
--- a/Sources/Model/GroupVersionResource.swift
+++ b/Sources/Model/GroupVersionResource.swift
@@ -21,7 +21,7 @@ import Foundation
 ///
 /// GroupVersionResource unambiguously identifies a resource.
 ///
-public struct GroupVersionResource: Hashable {
+public struct GroupVersionResource: Hashable, Codable {
 	/// The group of the resource.
 	public let group: String
 	/// The version of the resource.


### PR DESCRIPTION
I came across this coming handy when passing custom resources around to open them in new windows.