### PR TITLE
Make `Quantity.decimalValue` publicly readable

### DIFF
--- a/Sources/Model/Quantity.swift
+++ b/Sources/Model/Quantity.swift
@@ -96,7 +96,7 @@ public struct Quantity: ExpressibleByStringLiteral, ExpressibleByIntegerLiteral,
 
 	let value: String
 	var ok: Bool = true
-	var decimalValue: Decimal = 0
+	public private(set) var decimalValue: Decimal = 0
 	var unit: String = ""
 	var unitType: UnitType = .decimalSI
 


### PR DESCRIPTION
... as we needed the value in some places on the app in order do calculations with quantities. Let me know if this doesn't make sense 😅